### PR TITLE
Add code coverage to test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  tests_matrix:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,4 +27,30 @@ jobs:
         run: |
           bundle exec rake
         env:
+          COVERAGE: true
           RUBYOPT: -W:deprecated
+      - name: Rename coverage file by matrix run
+        run: mv coverage/coverage.xml coverage/coverage-ruby-${{ matrix.ruby }}.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-ruby-${{ matrix.ruby }}
+          path: coverage
+          if-no-files-found: error
+
+  upload_coverage:
+    name: Upload Coverage
+    runs-on: ubuntu-latest
+    needs:
+      - tests_matrix
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: coverage
+          pattern: coverage-ruby-*
+          merge-multiple: true
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: coverage
+          fail_ci_if_error: true

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,9 @@ source 'https://rubygems.org'
 gem "rake"
 gem "rspec"
 
+group :test do
+  gem "simplecov", require: false
+  gem "simplecov-cobertura"
+end
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.5.1)
+    docile (1.4.1)
     rake (13.2.1)
+    rexml (3.3.4)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -22,6 +25,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    strscan (3.1.0)
     thor (1.3.1)
 
 PLATFORMS
@@ -32,6 +45,8 @@ DEPENDENCIES
   envied!
   rake
   rspec
+  simplecov
+  simplecov-cobertura
 
 BUNDLED WITH
    2.5.17

--- a/lib/envied/configuration.rb
+++ b/lib/envied/configuration.rb
@@ -8,8 +8,8 @@ class ENVied
       instance_eval(&block) if block_given?
     end
 
-    def self.load(**options)
-      envfile = File.expand_path('Envfile')
+    def self.load(file='Envfile', **options)
+      envfile = File.expand_path(file)
       new(**options).tap do |v|
         v.instance_eval(File.read(envfile), envfile)
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe ENVied::Configuration do
   end
   attr_reader :config
 
+  describe '.load' do
+    it 'loads a sample Envfile' do
+      config = described_class.load(File.join(SAMPLES_PATH, "Envfile"))
+      expect(config.variables).to match_array([
+        ENVied::Variable.new(:REDIS_URL, :string, group: :default, default: "redis://localhost:6379"),
+        ENVied::Variable.new(:SECRET_KEY_BASE, :string, group: :production)
+      ])
+    end
+  end
+
   describe 'variables' do
     it 'results in an added variable' do
       with_envfile do

--- a/spec/samples/Envfile
+++ b/spec/samples/Envfile
@@ -1,0 +1,5 @@
+variable :REDIS_URL, :string, default: 'redis://localhost:6379'
+
+group :production do
+  variable :SECRET_KEY_BASE
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,12 @@
+if ENV.fetch("COVERAGE", false)
+  require "simplecov"
+  require "simplecov-cobertura"
+  SimpleCov.start do
+    add_filter %r{^/spec/}
+    formatter SimpleCov::Formatter::CoberturaFormatter
+  end
+end
+
 require "bundler/setup"
 require "envied"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ end
 require "bundler/setup"
 require "envied"
 
+SAMPLES_PATH = File.join(File.dirname(__FILE__), "samples")
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
When the `COVERAGE=` environment variable is present, then a code coverage report will be generated using simplecov and uploaded to Codecov.