### PR TITLE
Prep 0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## master / unreleased
+# Changelog
 
-* **BREAKING:** Reset library back to the v0.9.2.rc1 release
-* Resolve Ruby 2.7 kwargs deprecations to ensure Ruby 3.0+ support
-* Remove default values deprecation
-* Replace `coercible` dependency with local implementation [#49](https://github.com/eval/envied/pull/49)
-* Require Ruby 3.0+
+## 0.10.0 [☰](https://github.com/javierjulio/envied/compare/v0.9.1..v0.10.0)
+
+* **BREAKING:** This uses the v0.9.2.rc1 tag as its base due to abandonment of later alpha releases
+* Resolves Ruby 2.7 kwargs deprecations to ensure Ruby 3.0+ compatibility
+* Removes default values deprecation (default values remain supported for now)
+* Replaces `coercible` dependency with local implementation [#49](https://github.com/eval/envied/pull/49)
+* Requires Ruby 3.0+
 
 ## 0.9.1 / 2017-07-06
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    envied (0.9.2.rc1)
+    envied (0.10.0)
       thor (>= 0.15, < 2.0)
 
 GEM

--- a/lib/envied/version.rb
+++ b/lib/envied/version.rb
@@ -1,3 +1,3 @@
 class ENVied
-  VERSION = '0.9.2.rc1'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
With this release the gem has a new base starting from v0.9.2.rc1 so anything released after through 0.10.0.alhpaX has been removed. This release includes working Ruby 3.x support and removes the default values deprecation (default values remain supported for now).