### PR TITLE
Prep 0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.0 [☰](https://github.com/javierjulio/envied/compare/v0.10.0..v0.11.0)
+
+* Set gemspec metadata URLs (no library code changes)
+
 ## 0.10.0 [☰](https://github.com/javierjulio/envied/compare/v0.9.1..v0.10.0)
 
 * **BREAKING:** This uses the v0.9.2.rc1 tag as its base due to abandonment of later alpha releases

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    envied (0.10.0)
+    envied (0.11.0)
       thor (>= 0.15, < 2.0)
 
 GEM

--- a/lib/envied/version.rb
+++ b/lib/envied/version.rb
@@ -1,3 +1,3 @@
 class ENVied
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end


### PR DESCRIPTION
No user facing code changes to the library. This just sets the gemspec metadata with the new URLs.