### PR TITLE
Prep 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0 [☰](https://github.com/javierjulio/envied/compare/v0.11.0..v1.0.0)
+
+* **Breaking**: Removes CLI and thor dependency
+* Updates gemspec metadata URLs
+
 ## 0.11.0 [☰](https://github.com/javierjulio/envied/compare/v0.10.0..v0.11.0)
 
 * Set gemspec metadata URLs (no library code changes)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    envied (0.11.0)
+    envied (1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/envied/version.rb
+++ b/lib/envied/version.rb
@@ -1,3 +1,3 @@
 class ENVied
-  VERSION = '0.11.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
This release includes another gemspec metadata update and a breaking change: removes the CLI and thor dependency.