### PR TITLE
Replace CGI usage with URI for Ruby 3.5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* **Breaking**: Replace `CGI.parse` with `URI.decode_www_form` for hash type.
 * Bump minimum required Ruby version to 3.1
 
 ## 1.0.0 [☰](https://github.com/javierjulio/envied/compare/v0.11.0..v1.0.0)

--- a/lib/envied/coercer/envied_string.rb
+++ b/lib/envied/coercer/envied_string.rb
@@ -27,8 +27,8 @@ class ENVied::Coercer::ENViedString
   end
 
   def to_hash(str)
-    require 'cgi'
-    ::CGI.parse(str).map { |key, values| [key, values[0]] }.to_h
+    require 'uri'
+    ::URI.decode_www_form(str).map { |key, values| [key, values[0]] }.to_h
   end
 
   def to_string(str)

--- a/spec/coercer_spec.rb
+++ b/spec/coercer_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe ENVied::Coercer do
         {
           'a=1' => {'a' => '1'},
           'a=1&b=2' => {'a' => '1', 'b' => '2'},
-          'a=&b=2' => {'a' => '', 'b' => '2'},
+          'a=&b=2' => {'a' => nil, 'b' => '2'},
           'a&b=2' => {'a' => nil, 'b' => '2'},
         }.each do |value, hash|
           expect(coerce(value, :hash)).to eq hash

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe ENVied do
         end
 
         it 'yields hash from string' do
-          expect(ENVied.FOO).to eq({ 'a' => '1', 'b' => '', 'c' => nil })
+          expect(ENVied.FOO).to eq({ 'a' => '1', 'b' => nil, 'c' => nil })
         end
 
         it 'yields hash from an empty string' do


### PR DESCRIPTION
In Ruby 3.5, most of the `cgi` gem is removed which includes `CGI.parse` which we use for the hash variable type. We can replace that with `URI.decode_www_form` but it has some slight differences. Seems any blank value now comes back as `nil` rather than `nil` or an empty string depending on the case so this is a breaking change. We'll release in a new major version. This removes any `cgi` dependency as well.